### PR TITLE
Add *.sethforprivacy.com services

### DIFF
--- a/services.json
+++ b/services.json
@@ -31,7 +31,8 @@
       "https://libreddit.flux.industries",
       "https://libreddit.drivet.xyz",
       "https://lr.oversold.host",
-      "https://libreddit.de"
+      "https://libreddit.de",
+      "https://libreddit.sethforprivacy.com"
     ]
   },
   {
@@ -87,7 +88,8 @@
       "https://invidious.hub.ne.kr",
       "https://yt.artemislena.eu",
       "https://youtube.076.ne.jp",
-      "https://invidious.namazso.eu"
+      "https://invidious.namazso.eu",
+      "https://invidious.sethforprivacy.com"
     ]
   },
   {
@@ -139,7 +141,8 @@
       "https://lu-nitter.resolv.ee",
       "https://is-nitter.resolv.ee",
       "https://cy-nitter.resolv.ee",
-      "https://tweet.lambda.dance"
+      "https://tweet.lambda.dance",
+      "https://nitter.sethforprivacy.com"
     ]
   },
   {


### PR DESCRIPTION
I noticed the hard-coded list only had a couple of my public services, so I added my Libreddit, Invidious, and Nitter instances.

You can see uptime stats for each here:

https://status.sethforprivacy.com/status

Edit: This is an awesome and much-needed service, and has been extremely helpful when my Whoogle instance gets rate limited! Love the idea, keep up the great work :)