### PR TITLE
Preserve redirect with `/_/` path prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ erl_crash.dump
 
 # Ignore results from update script
 .update-result*
+
+*.rdb

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Farside's routing is very minimal, with only the following routes:
     jumping between instances by navigating back.
   - Ex: `/_/nitter` -> nitter instance A -> (navigate back one page) -> nitter
     instance B -> ...
+  - *Note: Uses Javascript to preserve the page in history*
 
 When a service is requested with the `/:service/...` endpoint, Farside requests
 the list of working instances from Redis and returns a random one from the list

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Farside's routing is very minimal, with only the following routes:
     URL>/r/popular`
   - Note that a path is not required. `/libreddit` for example will still
     redirect the user to a working libreddit instance
+- `/_/:service/*glob`
+  - Achieves the same redirect as the main `/:service/*glob` endpoint, but
+    preserves a short landing page in the browser's history to allow quickly
+    jumping between instances by navigating back.
+  - Ex: `/_/nitter` -> nitter instance A -> (navigate back one page) -> nitter
+    instance B -> ...
 
 When a service is requested with the `/:service/...` endpoint, Farside requests
 the list of working instances from Redis and returns a random one from the list

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,6 +9,7 @@ config :farside,
   previous_suffix: "-previous",
   services_json: "services.json",
   index: "index.eex",
+  route: "route.eex",
   headers: [
     {"User-Agent", "Mozilla/5.0 (Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"},
     {"Accept", "text/html"},

--- a/lib/farside/router.ex
+++ b/lib/farside/router.ex
@@ -1,5 +1,6 @@
 defmodule Farside.Router do
   @index Application.fetch_env!(:farside, :index)
+  @route Application.fetch_env!(:farside, :route)
 
   use Plug.Router
 
@@ -21,6 +22,19 @@ defmodule Farside.Router do
   get "/ping" do
     # Useful for app healthcheck
     {:ok, resp} = Redix.command(:redix, ["PING"])
+    send_resp(conn, 200, resp)
+  end
+
+  get "/r/:service/*glob" do
+    r_path = String.slice(conn.request_path, 2..-1)
+
+    resp =
+      EEx.eval_file(
+        @route,
+        service: service,
+        instance_url: r_path
+      )
+
     send_resp(conn, 200, resp)
   end
 

--- a/lib/farside/router.ex
+++ b/lib/farside/router.ex
@@ -25,7 +25,7 @@ defmodule Farside.Router do
     send_resp(conn, 200, resp)
   end
 
-  get "/r/:service/*glob" do
+  get "/_/:service/*glob" do
     r_path = String.slice(conn.request_path, 2..-1)
 
     resp =

--- a/route.eex
+++ b/route.eex
@@ -1,0 +1,10 @@
+<head>
+  <title>Farside Redirect - <%= service %></title>
+  <meta http-equiv="refresh" content="1; url=<%= instance_url %>">
+  <script>
+    history.pushState({page: 1}, "Farside Redirect");
+  </script>
+</head>
+<body>
+  <span>Redirecting to <%= service %> instance...
+</body>


### PR DESCRIPTION
This adds a straightforward way of preserving Farside's redirecting
behavior in the user's browser history. That way if an instance becomes
unavailable between the 5 min scans, the user can opt to navigate back
one page and be taken to a new instance.

This is accomplished using a single line of JS, and could potentially
work as the default behavior of Farside (with the current default
behavior requiring a path prefix instead). This should be revisited down
the road when more people are using this service.

Fixes #7 