### PR TITLE
Move artemislena libreddit instance to teddit

### DIFF
--- a/services-full.json
+++ b/services-full.json
@@ -19,7 +19,6 @@
       "https://libreddit.domain.glass",
       "https://libreddit.sugoma.tk",
       "https://libreddit.trevorthalacker.com",
-      "https://reddit.artemislena.eu",
       "https://r.nf",
       "https://libreddit.some-things.org",
       "https://reddit.stuehieyr.com",
@@ -66,6 +65,7 @@
       "https://teddit.tokhmi.xyz",
       "https://teddit.totaldarkness.net",
       "https://teddit.zaggy.nl",
+      "https://teddit.artemislena.eu",
       "https://wiki.privacytools.io"
     ]
   },

--- a/services.json
+++ b/services.json
@@ -9,7 +9,6 @@
       "https://libreddit.40two.app",
       "https://reddit.phii.me",
       "https://libreddit.sugoma.tk",
-      "https://reddit.artemislena.eu",
       "https://libreddit.some-things.org",
       "https://reddit.stuehieyr.com",
       "https://libreddit.igna.rocks",
@@ -37,7 +36,8 @@
       "https://teddit.sethforprivacy.com",
       "https://teddit.tinfoil-hat.net",
       "https://teddit.totaldarkness.net",
-      "https://teddit.zaggy.nl"
+      "https://teddit.zaggy.nl",
+      "https://teddit.artemislena.eu"
     ]
   },
   {


### PR DESCRIPTION
@benbusby Reason: Artemislena moved to teddit, their old libreddit URL redirects to their teddit instance.