### PR TITLE
Add auto update instances for libreddit

### DIFF
--- a/.github/workflows/update-instances.yml
+++ b/.github/workflows/update-instances.yml
@@ -190,6 +190,21 @@ jobs:
         #apply_update
 
         # ==============================================================
+        # libreddit update
+        # ==============================================================
+        curl -s https://raw.githubusercontent.com/libreddit/libreddit-instances/master/instances.json | \
+          jq '[
+            .instances[] |
+            select(.url) |
+            .url ] |
+            sort' > libreddit-tmp.json
+        jq --slurpfile libreddit libreddit-tmp.json \
+          '( .[] | select(.type == "libreddit") )
+          .instances |= $libreddit[0]' services-full.json > services-tmp.json
+
+        apply_update
+
+        # ==============================================================
         # TODO: Update instances for other services
         # ==============================================================
 

--- a/services-full.json
+++ b/services-full.json
@@ -2,7 +2,7 @@
   {
     "type": "libreddit",
     "test_url": "/r/popular",
-    "fallback": "https://libredd.it",
+    "fallback": "https://libreddit.spike.codes",
     "instances": [
       "https://libreddit.albony.xyz",
       "https://libredd.it",

--- a/services.json
+++ b/services.json
@@ -2,7 +2,7 @@
   {
     "type": "libreddit",
     "test_url": "/r/popular",
-    "fallback": "https://libredd.it",
+    "fallback": "https://libreddit.spike.codes",
     "instances": [
       "https://libredd.it",
       "https://libreddit.spike.codes",


### PR DESCRIPTION
Add auto update instances for libreddit from their [official repository](https://github.com/libreddit/libreddit-instances), and change fallback URL to official instance's URL.