### PR TITLE
Cleanup nitter instances

### DIFF
--- a/services-full.json
+++ b/services-full.json
@@ -190,8 +190,6 @@
       "https://twitter.076.ne.jp",
       "https://nitter.sethforprivacy.com",
       "https://nitter.bus-hit.me",
-      "https://nttr.stream",
-      "https://de.nttr.stream",
       "https://n.l5.ca",
       "https://unofficialbird.com",
       "https://nitter.ungovernable.men"

--- a/services-full.json
+++ b/services-full.json
@@ -183,7 +183,6 @@
       "https://twitter.censors.us",
       "https://nitter.grimneko.de",
       "https://nitter.koyu.space",
-      "https://n.hyperborea.cloud",
       "https://twitter.076.ne.jp",
       "https://nitter.sethforprivacy.com",
       "https://nitter.bus-hit.me",

--- a/services-full.json
+++ b/services-full.json
@@ -174,7 +174,6 @@
       "https://nitter.mailstation.de",
       "https://n.actionsack.com",
       "https://nitter.cattube.org",
-      "https://nitter.hu",
       "https://nitter.moomoo.me",
       "https://bird.trom.tf",
       "https://nitter.it",

--- a/services-full.json
+++ b/services-full.json
@@ -173,7 +173,6 @@
       "https://nitter.namazso.eu",
       "https://nitter.mailstation.de",
       "https://n.actionsack.com",
-      "https://nitter.cattube.org",
       "https://nitter.moomoo.me",
       "https://bird.trom.tf",
       "https://nitter.it",

--- a/services-full.json
+++ b/services-full.json
@@ -169,7 +169,6 @@
       "https://nitter.kavin.rocks",
       "https://nitter.vxempire.xyz",
       "https://nitter.unixfox.eu",
-      "https://nitter.eu",
       "https://nitter.namazso.eu",
       "https://n.actionsack.com",
       "https://nitter.moomoo.me",

--- a/services-full.json
+++ b/services-full.json
@@ -183,7 +183,6 @@
       "https://twitter.censors.us",
       "https://nitter.grimneko.de",
       "https://nitter.koyu.space",
-      "https://nitter.ir",
       "https://n.hyperborea.cloud",
       "https://twitter.076.ne.jp",
       "https://nitter.sethforprivacy.com",

--- a/services-full.json
+++ b/services-full.json
@@ -163,7 +163,6 @@
       "https://nitter.net",
       "https://nitter.42l.fr",
       "https://nitter.pussthecat.org",
-      "https://nitter.nixnet.services",
       "https://nitter.fdn.fr",
       "https://nitter.1d4.us",
       "https://nitter.kavin.rocks",

--- a/services-full.json
+++ b/services-full.json
@@ -171,7 +171,6 @@
       "https://nitter.unixfox.eu",
       "https://nitter.eu",
       "https://nitter.namazso.eu",
-      "https://nitter.mailstation.de",
       "https://n.actionsack.com",
       "https://nitter.moomoo.me",
       "https://bird.trom.tf",

--- a/services-full.json
+++ b/services-full.json
@@ -175,7 +175,6 @@
       "https://n.actionsack.com",
       "https://nitter.cattube.org",
       "https://nitter.hu",
-      "https://twitr.gq",
       "https://nitter.moomoo.me",
       "https://bird.trom.tf",
       "https://nitter.it",

--- a/services-full.json
+++ b/services-full.json
@@ -184,7 +184,6 @@
       "https://nitter.grimneko.de",
       "https://nitter.koyu.space",
       "https://nitter.ir",
-      "https://n.0x0.st",
       "https://n.hyperborea.cloud",
       "https://twitter.076.ne.jp",
       "https://nitter.sethforprivacy.com",

--- a/services-full.json
+++ b/services-full.json
@@ -182,7 +182,6 @@
       "https://nitter.it",
       "https://twitter.censors.us",
       "https://nitter.grimneko.de",
-      "https://nitter.koyu.space",
       "https://twitter.076.ne.jp",
       "https://nitter.sethforprivacy.com",
       "https://nitter.bus-hit.me",

--- a/services-full.json
+++ b/services-full.json
@@ -175,7 +175,6 @@
       "https://n.actionsack.com",
       "https://nitter.cattube.org",
       "https://nitter.hu",
-      "https://nitter.exonip.de",
       "https://twitr.gq",
       "https://nitter.moomoo.me",
       "https://bird.trom.tf",

--- a/services-full.json
+++ b/services-full.json
@@ -167,7 +167,6 @@
       "https://nitter.fdn.fr",
       "https://nitter.1d4.us",
       "https://nitter.kavin.rocks",
-      "https://nitter.vxempire.xyz",
       "https://nitter.unixfox.eu",
       "https://nitter.namazso.eu",
       "https://n.actionsack.com",

--- a/services-full.json
+++ b/services-full.json
@@ -186,7 +186,6 @@
       "https://nitter.ir",
       "https://n.0x0.st",
       "https://n.hyperborea.cloud",
-      "https://nitter.ca",
       "https://twitter.076.ne.jp",
       "https://nitter.sethforprivacy.com",
       "https://nitter.bus-hit.me",


### PR DESCRIPTION
I clicked through all of the nitter instances and removes the ones that are no longer working. Some of them redirect to malware sites or have domains parked that are for sale, others are just offline or require authentication.