### PR TITLE
Add relation between google parent service and whoogle

### DIFF
--- a/lib/farside.ex
+++ b/lib/farside.ex
@@ -18,6 +18,7 @@ defmodule Farside do
   @tiktok_regex ~r/tiktok.com|proxitok/
   @imdb_regex ~r/imdb.com|libremdb/
   @quora_regex ~r/quora.com|quetre/
+  @google_regex ~r/google.com|whoogle/
 
   @parent_services %{
     @youtube_regex => ["invidious", "piped"],
@@ -31,7 +32,8 @@ defmodule Farside do
     @gtranslate_regex => ["lingva"],
     @tiktok_regex => ["proxitok"],
     @imdb_regex => ["libremdb"],
-    @quora_regex => ["quetre"]
+    @quora_regex => ["quetre"],
+    @google_regex => ["whoogle"]
   }
 
   def get_services_map do


### PR DESCRIPTION
Add relation between google parent service and whoogle so that farside can redirect google.com to a whoogle instance.