### PR TITLE
Add GotHub support

### DIFF
--- a/.github/workflows/update-instances.yml
+++ b/.github/workflows/update-instances.yml
@@ -217,6 +217,18 @@ jobs:
         apply_update
 
         # ==============================================================
+        # GotHub update
+        # ==============================================================
+
+        curl -s https://codeberg.org/gothub/gothub-instances/raw/branch/master/instances.json | \
+          jq '[.[] | .link]' > gothub-tmp.json
+        jq --slurpfile gothub-tmp.json \
+          '(.[] | select(.type == "gothub") )
+          .instances |= $gothub[0]' services-full.json > services-tmp.json
+
+          apply_update
+
+        # ==============================================================
         # TODO: Update instances for other services
         # ==============================================================
 

--- a/lib/farside.ex
+++ b/lib/farside.ex
@@ -20,6 +20,7 @@ defmodule Farside do
   @quora_regex ~r/quora.com|quetre/
   @gsearch_regex ~r/google.com\/search|whoogle/
   @fandom_regex ~r/fandom.com|breezewiki/
+  @github_regex ~r/github.com|gothub/
   @stackoverflow_regex ~r/stackoverflow.com|anonymousoverflow/
 
   @parent_services %{
@@ -37,6 +38,7 @@ defmodule Farside do
     @quora_regex => ["quetre"],
     @gsearch_regex => ["whoogle"],
     @fandom_regex => ["breezewiki"],
+    @github_regex => ["gothub"],
     @stackoverflow_regex => ["anonymousoverflow"]
   }
 

--- a/services-full.json
+++ b/services-full.json
@@ -570,6 +570,20 @@
     ]
   },
   {
+    "type": "gothub",
+    "test_url": "/benbusby/farside",
+    "fallback": "https://gothub.projectsegfau.lt",
+    "instances": [
+      "https://gh.bloatcat.tk",
+      "https://gothub.lunar.icu",
+      "https://gothub.no-logs.com",
+      "https://gh.owo.si",
+      "https://gothub.projectsegfau.lt",
+      "https://gh.whateveritworks.org",
+      "https://gothub.dev.projectsegfau.lt"
+    ]
+  },
+  {
     "type": "anonymousoverflow",
     "test_url": "/questions/6591213/how-do-i-rename-a-local-git-branch",
     "fallback": "https://code.whatever.social",

--- a/services.json
+++ b/services.json
@@ -522,6 +522,19 @@
     ]
   },
   {
+    "type": "gothub",
+    "test_url": "/benbusby/farside",
+    "fallback": "https://gothub.projectsegfau.lt",
+    "instances": [
+      "https://gh.bloatcat.tk",
+      "https://gothub.lunar.icu",
+      "https://gothub.no-logs.com",
+      "https://gh.owo.si",
+      "https://gothub.projectsegfau.lt",
+      "https://gothub.dev.projectsegfau.lt"
+    ]
+  },
+  {
     "type": "anonymousoverflow",
     "test_url": "/questions/6591213/how-do-i-rename-a-local-git-branch",
     "fallback": "https://code.whatever.social",


### PR DESCRIPTION
[GotHub](https://codeberg.org/gothub/gothub) is Alternative front-end for GitHub

- Most stable and official instance is [gothub.projectsegfau.lt](https://gothub.projectsegfau.lt)
- Also, auto moderation based on if instance online or not: [gothub-instances source code](https://codeberg.org/gothub/gothub-instances)
- `test_url` is this repository (ofc \:D). 
  - [Stable](https://gothub.projectsegfau.lt/benbusby/farside) | [Farside {not supported yet}](https://farside.link/gothub/benbusby/farside)