### PR TITLE
Add auto update instances for LibreX

### DIFF
--- a/.github/workflows/update-instances.yml
+++ b/.github/workflows/update-instances.yml
@@ -246,6 +246,22 @@ jobs:
           apply_update
 
         # ==============================================================
+        # librex update
+        # ==============================================================
+        curl -s https://raw.githubusercontent.com/Ahwxorg/LibreY/main/instances.json | \
+          jq '[
+            .instances |
+            .[] |
+            select(.librey|not) |
+            .clearnet] |
+            sort' > librex-tmp.json
+        jq --slurpfile librex librex-tmp.json \
+          '( .[] | select(.type == "librex") )
+          .instances |= $librex[0]' services-full.json > services-tmp.json
+
+        apply_update
+
+        # ==============================================================
         # TODO: Update instances for other services
         # ==============================================================
 

--- a/services-full.json
+++ b/services-full.json
@@ -456,7 +456,7 @@
   {
     "type": "librex",
     "test_url": "/search.php?q=<%=query%>",
-    "fallback": "https://search.femboy.hu",
+    "fallback": "https://librex.myroware.eu",
     "instances": [
       "https://search.femboy.hu",
       "https://lx.vern.cc",

--- a/services.json
+++ b/services.json
@@ -421,7 +421,7 @@
   {
     "type": "librex",
     "test_url": "/search.php?q=<%=query%>",
-    "fallback": "https://search.femboy.hu",
+    "fallback": "https://librex.myroware.eu",
     "instances": [
       "https://search.femboy.hu",
       "https://lx.vern.cc",


### PR DESCRIPTION
Add auto update instances for LibreX from [LibreY (LibreX fork) instances list](https://github.com/Ahwxorg/LibreY/blob/main/instances.json) and update fallback URL. to currently working instances as LibreX's official instance is already down.