### PR TITLE
Add LibreY support

### DIFF
--- a/.github/workflows/update-instances.yml
+++ b/.github/workflows/update-instances.yml
@@ -246,6 +246,22 @@ jobs:
           apply_update
 
         # ==============================================================
+        # librey update
+        # ==============================================================
+        curl -s https://raw.githubusercontent.com/Ahwxorg/LibreY/main/instances.json | \
+          jq '[
+            .instances |
+            .[] |
+            select(.librey == true) |
+            .clearnet] |
+            sort' > librey-tmp.json
+        jq --slurpfile librey librey-tmp.json \
+          '( .[] | select(.type == "librey") )
+          .instances |= $librey[0]' services-full.json > services-tmp.json
+
+        apply_update
+
+        # ==============================================================
         # TODO: Update instances for other services
         # ==============================================================
 

--- a/services-full.json
+++ b/services-full.json
@@ -595,5 +595,30 @@
       "https://4get.ca",
       "https://4get.zzls.xyz"
     ]
+  },
+  {
+    "type": "librey",
+    "test_url": "/search.php?q=<%=query%>",
+    "fallback": "https://search.ahwx.org",
+    "instances": [
+      "https://librex.me",
+      "https://librex.nohost.network",
+      "https://librex.retro-hax.net",
+      "https://librex.revvy.de",
+      "https://librex.yogeshlamichhane.com.np",
+      "https://librex.zzls.xyz",
+      "https://librey.baczek.me",
+      "https://librey.bloatcat.tk/",
+      "https://librey.org",
+      "https://librey.spaceint.fr",
+      "https://lx.benike.me",
+      "https://lx.vern.cc",
+      "https://search.ahwx.org",
+      "https://search.davidovski.xyz",
+      "https://search.funami.tech",
+      "https://search.pabloferreiro.es",
+      "https://search.ratakor.com",
+      "https://search2.ahwx.org"
+    ]
   }
 ]

--- a/services.json
+++ b/services.json
@@ -552,5 +552,30 @@
       "https://4get.ca",
       "https://4get.zzls.xyz"
     ]
+  },
+  {
+    "type": "librey",
+    "test_url": "/search.php?q=<%=query%>",
+    "fallback": "https://search.ahwx.org",
+    "instances": [
+      "https://librex.me",
+      "https://librex.nohost.network",
+      "https://librex.retro-hax.net",
+      "https://librex.revvy.de",
+      "https://librex.yogeshlamichhane.com.np",
+      "https://librex.zzls.xyz",
+      "https://librey.baczek.me",
+      "https://librey.bloatcat.tk/",
+      "https://librey.org",
+      "https://librey.spaceint.fr",
+      "https://lx.benike.me",
+      "https://lx.vern.cc",
+      "https://search.ahwx.org",
+      "https://search.davidovski.xyz",
+      "https://search.funami.tech",
+      "https://search.pabloferreiro.es",
+      "https://search.ratakor.com",
+      "https://search2.ahwx.org"
+    ]
   }
 ]


### PR DESCRIPTION
[LibreY](https://github.com/Ahwxorg/LibreY) is fork of currently inactive LibreX.

- most up to date and stable instance: [search.ahwx.org](https://search.ahwx.org)
- [Instances list](https://search.ahwx.org/instances.php) / [JSON](https://github.com/Ahwxorg/LibreY/blob/main/instances.json)