### PR TITLE
update list of 4get instances according to semi-official decentralized list

### DIFF
--- a/services-full.json
+++ b/services-full.json
@@ -528,10 +528,15 @@
     "fallback": "https://4get.ca",
     "instances": [
       "https://4get.ca",
-      "https://4get.zzls.xyz",
-      "https://4getus.zzls.xyz",
+      "https://4g.ggtyler.dev",
       "https://4get.silly.computer",
-      "https://4get.cynic.moe"
+      "https://4getus.zzls.xyz",
+      "https://4get.lvkaszus.pl",
+      "https://4get.konakona.moe",
+      "https://4get.perennialte.ch",
+      "https://4get.sijh.net",
+      "https://4get.hbubli.cc",
+      "https://4get.zzls.xyz"
     ]
   },
   {

--- a/services.json
+++ b/services.json
@@ -482,10 +482,15 @@
     "fallback": "https://4get.ca",
     "instances": [
       "https://4get.ca",
-      "https://4get.zzls.xyz",
-      "https://4getus.zzls.xyz",
+      "https://4g.ggtyler.dev",
       "https://4get.silly.computer",
-      "https://4get.cynic.moe"
+      "https://4getus.zzls.xyz",
+      "https://4get.lvkaszus.pl",
+      "https://4get.konakona.moe",
+      "https://4get.perennialte.ch",
+      "https://4get.sijh.net",
+      "https://4get.hbubli.cc",
+      "https://4get.zzls.xyz"
     ]
   },
   {


### PR DESCRIPTION
4get, at the time of writing, has a dynamic instance list at https://4get.ca/instances that crawls peer lists of associated instances to compile a list of living ones sorted by ping.

I updated both `services.json` and `services-full.json` using this list, with the only deletion being 4get.cynic.moe, which is an alternate domain for another instance.

It's unclear to me which instances (if any) use cloudflare, and if they plan to move towards/against it, so I updated both data files with the rationale that the script would filter it anyway.