### PR TITLE
remove dead wikiless link

### DIFF
--- a/services-full.json
+++ b/services-full.json
@@ -363,7 +363,6 @@
     "test_url": "/wiki/Wikipedia?lang=en",
     "fallback": "https://wikiless.org",
     "instances": [
-      "https://wiki.604kph.xyz",
       "https://wiki.adminforge.de",
       "https://wiki.froth.zone",
       "https://wiki.privacytools.io",

--- a/services.json
+++ b/services.json
@@ -331,7 +331,6 @@
     "test_url": "/wiki/Wikipedia?lang=en",
     "fallback": "https://wikiless.org",
     "instances": [
-      "https://wiki.604kph.xyz",
       "https://wiki.adminforge.de",
       "https://wiki.froth.zone",
       "https://wiki.slipfox.xyz",


### PR DESCRIPTION
`https://wiki.604kph.xyz` is redirected to `http://ww25.wiki.604kph.xyz/?subid1=x`