### PR TITLE
Add missing services from services.json to mappings

### DIFF
--- a/services/mappings.go
+++ b/services/mappings.go
@@ -24,8 +24,8 @@ var regexMap = []RegexMapping{
 	},
 	{
 		// Reddit
-		Pattern: regexp.MustCompile(`reddit\.com|libreddit|redlib`),
-		Targets: []string{"libreddit", "redlib"},
+		Pattern: regexp.MustCompile(`reddit\.com|libreddit|redlib|teddit`),
+		Targets: []string{"libreddit", "redlib", "teddit"},
 	},
 	{
 		// Google Search
@@ -59,8 +59,8 @@ var regexMap = []RegexMapping{
 	},
 	{
 		// Google Translate
-		Pattern: regexp.MustCompile(`translate\.google\.com|lingva`),
-		Targets: []string{"lingva"},
+		Pattern: regexp.MustCompile(`translate\.google\.com|lingva|simplytranslate`),
+		Targets: []string{"lingva", "simplytranslate"},
 	},
 	{
 		// TikTok
@@ -91,6 +91,11 @@ var regexMap = []RegexMapping{
 		// StackOverflow
 		Pattern: regexp.MustCompile(`stackoverflow\.com|anonymousoverflow`),
 		Targets: []string{"anonymousoverflow"},
+	},
+	{
+		// Genius
+		Pattern: regexp.MustCompile(`genius\.com|dumb`),
+		Targets: []string{"dumb"},
 	},
 }
 


### PR DESCRIPTION
It looks like in the recent golang rewrite, some of the services listed on the farside.link homepage and in the services.json files no longer work - visiting these services yields error 400 and the error message `No routing found for `. Adding `teddit`, `simplytranslate`, and `dumb` to the mappings here seems to fix them. The same naive fix didn't seem to work for `librex`, `4get`, or `tent`, so I'm not including those in this PR, but they are also not working (possibly due to the query parameter issue I opened separately).

e.g.

https://farside.link/dumb/Kendrick-lamar-not-like-us-lyrics